### PR TITLE
404 error page adjustments

### DIFF
--- a/client/src/components/ErrorPage/index.jsx
+++ b/client/src/components/ErrorPage/index.jsx
@@ -20,6 +20,10 @@ const ErrorCodeMsg = styled.h1`
 
   font-size: 4.5rem;
   animation: errorPageHeadingExpand 1s;
+
+  @media(max-width: 500px) {
+    font-size: 3.5rem;
+  }
 `;
 
 const ErrorMsgHeading = styled.h3`
@@ -35,6 +39,10 @@ const ErrorMsgHeading = styled.h3`
   font-size: 2.25rem;
   margin: 25px 0  50px;
   animation: errorCodeFadeIn 1.5s 2s backwards;
+
+  @media(max-width: 500px) {
+    font-size: 2rem;
+  }
 `;
 
 function LandingPage() {

--- a/client/src/components/ErrorPage/index.jsx
+++ b/client/src/components/ErrorPage/index.jsx
@@ -4,7 +4,8 @@ import styled from 'styled-components';
 const errorMsg = 'Oops, this is not the page you are looking for....';
 
 const Container = styled.main`
-  margin: 100px 5% 50px;
+  min-height: calc(100vh - 200px);
+  margin: 125px 7.5% 0;
 `;
 
 const ErrorCodeMsg = styled.h1`

--- a/client/src/components/ErrorPage/index.jsx
+++ b/client/src/components/ErrorPage/index.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 const errorMsg = 'Oops, this is not the page you are looking for....';
 
+// Subtract pixels to prevent unnecessary vertical scrollbar (accounts for fixed nav bar at the top and other elements)
 const Container = styled.main`
   min-height: calc(100vh - 200px);
   margin: 125px 7.5% 0;

--- a/client/src/components/Layout/Footer.jsx
+++ b/client/src/components/Layout/Footer.jsx
@@ -10,12 +10,13 @@ const Footer = () => {
 };
 const FooterContainer = styled.div`
   text-align: center;
-  position: fixed;
   bottom: 0;
   width: 100%;
   color: #333333;
   background: #f8f8f8;
   padding-bottom: 10px;
+  margin: 15px 0;
+  z-index: 0;
 `;
 
 export default Footer;

--- a/client/src/components/Layout/index.jsx
+++ b/client/src/components/Layout/index.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import NavBar from './NavBar.jsx';
 import Footer from './Footer.jsx';
 import { theme } from '../../styles/themes';
+import styled from 'styled-components';
 
 // GlobalStyles will go here
 
@@ -11,9 +12,11 @@ const Layout = ({ children }) => {
   return (
     <>
       <Grommet theme={theme}>
-        <NavBar />
-        {children}
-        <Footer />
+        <Container>
+          <NavBar />
+          {children}
+          <Footer />
+        </Container>
       </Grommet>
     </>
   );
@@ -25,5 +28,10 @@ Layout.propTypes = {
     PropTypes.node
   ]).isRequired
 };
+
+const Container = styled.main`
+  width: 100%;
+  position: relative;
+`;
 
 export default Layout;


### PR DESCRIPTION
# Description

Sets the copyright footer in 404 error page to be at the bottom of the page without being in a fixed position and also adds font resizing for mobile view

## Checklist

Remove any items which are not applicable.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas