### PR TITLE
Remove username return field from addUser mutation

### DIFF
--- a/client/src/auth/authQueries.js
+++ b/client/src/auth/authQueries.js
@@ -10,7 +10,6 @@ const queries = {
         mutation AddUser($authToken: String!) {
           addUser(authToken: $authToken) {
             id
-            username
             email
             roleId
           }


### PR DESCRIPTION
# Description

Removes the `username` return field from addUser mutation **(reason: because it is unused)**.

## Checklist

- [X] I have performed a self-review of my own code
