### PR TITLE
Revert "Remove username return field from addUser mutation"

### DIFF
--- a/client/src/auth/authQueries.js
+++ b/client/src/auth/authQueries.js
@@ -10,6 +10,7 @@ const queries = {
         mutation AddUser($authToken: String!) {
           addUser(authToken: $authToken) {
             id
+            username
             email
             roleId
           }


### PR DESCRIPTION
Reverts labs14-stampd/frontend#64

Seems like the `username` return field in the addUser mutation is used after all....