### PR TITLE
Add username field to the authToken used in the addUser mutation

### DIFF
--- a/client/src/auth/authWrapper.jsx
+++ b/client/src/auth/authWrapper.jsx
@@ -40,12 +40,18 @@ export const Auth0Provider = ({
 
       if (isAuthenticatedFromAuth0) {
         const userFromAuth0 = await auth0FromHook.getUser();
+
+        // Change property name from nickname to username
+        userFromAuth0.username = userFromAuth0.nickname;
+        userFromAuth0.nickname = undefined;
+
         setUser(userFromAuth0);
 
         const authToken = jwt.sign(
           userFromAuth0,
           process.env.REACT_APP_AUTH_TOKEN
         );
+
         try {
           const result = await queries.register({ authToken });
           dispatchGlobal({ type: 'REGISTER', payload: result.data.addUser });


### PR DESCRIPTION
# Description

Ensures that the `authToken` sent to the back end will have a usable `username` field (this involves renaming the Auth0 `nickname` property).

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
